### PR TITLE
fix: channel + event wrapper typing

### DIFF
--- a/index.channel.ts
+++ b/index.channel.ts
@@ -17,7 +17,6 @@ import fetch from 'node-fetch';
 import { Attachment } from '@/attachment/schemas/attachment.schema';
 import { AttachmentService } from '@/attachment/services/attachment.service';
 import { ChannelService } from '@/channel/channel.service';
-import EventWrapper from '@/channel/lib/EventWrapper';
 import ChannelHandler from '@/channel/lib/Handler';
 import { SubscriberCreateDto } from '@/chat/dto/subscriber.dto';
 import { VIEW_MORE_PAYLOAD } from '@/chat/helpers/constants';
@@ -808,7 +807,7 @@ export default class MessengerHandler extends ChannelHandler<
    * @returns The messenger's response, otherwise an error
    */
   async sendMessage(
-    event: EventWrapper<any, any>,
+    event: MessengerEventWrapper,
     envelope: StdOutgoingEnvelope,
     options: BlockOptions,
     _context?: any,

--- a/wrapper.ts
+++ b/wrapper.ts
@@ -21,6 +21,7 @@ import {
 import { Payload } from '@/chat/schemas/types/quick-reply';
 
 import MessengerHandler from './index.channel';
+import { MESSENGER_CHANNEL_NAME } from './settings';
 import { Messenger } from './types';
 
 type MessengerEventAdapter =
@@ -75,7 +76,8 @@ type MessengerEventAdapter =
 
 export default class MessengerEventWrapper extends EventWrapper<
   MessengerEventAdapter,
-  Messenger.Event
+  Messenger.Event,
+  typeof MESSENGER_CHANNEL_NAME
 > {
   /**
    * Constructor : channel's event wrapper


### PR DESCRIPTION
The following PR fixes the typing issues we have with ChannelHandler VS EventWrapper when we enforce the typing for the subscriber's channel data.