### PR TITLE
fix: parse int

### DIFF
--- a/index.channel.ts
+++ b/index.channel.ts
@@ -972,7 +972,7 @@ export default class MessengerHandler extends ChannelHandler<
       return {
         file: response.data,
         type: response.headers['content-type'],
-        size: parseInt(),
+        size: parseInt(response.headers['content-length']),
       };
     }
 


### PR DESCRIPTION
This PR fixes the content length parseInt() call when downloading attachments.