### PR TITLE
fix: handle fetching attachment errors

### DIFF
--- a/index.channel.ts
+++ b/index.channel.ts
@@ -116,10 +116,6 @@ export default class MessengerHandler extends ChannelHandler<
       const files: AttachmentFile[] = [];
       for (const remoteFile of remoteFiles) {
         try {
-          if (!remoteFile.payload.url) {
-            throw new Error('Unable to find the payload URL!');
-          }
-
           const response = await this.httpService.axiosRef.get(
             remoteFile.payload.url,
             {

--- a/index.channel.ts
+++ b/index.channel.ts
@@ -117,7 +117,7 @@ export default class MessengerHandler extends ChannelHandler<
       for (const remoteFile of remoteFiles) {
         try {
           const response = await this.httpService.axiosRef.get(
-            remoteFile.payload.url,
+            remoteFile.payload.url!,
             {
               responseType: 'stream',
             },

--- a/wrapper.ts
+++ b/wrapper.ts
@@ -9,13 +9,13 @@
 import { Attachment } from '@/attachment/schemas/attachment.schema';
 import EventWrapper from '@/channel/lib/EventWrapper';
 import { AttachmentPayload, FileType } from '@/chat/schemas/types/attachment';
+import { PayloadType } from '@/chat/schemas/types/button';
 import {
   IncomingMessageType,
   StdEventType,
   StdIncomingMessage,
 } from '@/chat/schemas/types/message';
 import { Payload } from '@/chat/schemas/types/quick-reply';
-import { PayloadType } from '@/chat/schemas/types/button';
 
 import MessengerHandler from './index.channel';
 import { MESSENGER_CHANNEL_NAME } from './settings';


### PR DESCRIPTION
We can notice that asynchronous errors within a for loop can lead to unexpected behavior, such as infinite loops (memory heap)